### PR TITLE
Matrix12315 patch 1

### DIFF
--- a/playground/templates/village/home.html
+++ b/playground/templates/village/home.html
@@ -168,7 +168,7 @@
         el: '#msg',
         data: {
             parent: "phaser-canvas",
-            assets_root: "{% static '' %}".replace(/\/$/, ""),
+            assets_root: "{% static '' %}".replace(/\/$/, ""), // avoid the "//" in address like http://127.0.0.1:8000/static//assets/village/tilemap/tilemap.json
             urls: {
                 start_game: "{% url 'start_game' %}",
                 agent_think: "{% url 'agent_think' %}",

--- a/playground/templates/village/home.html
+++ b/playground/templates/village/home.html
@@ -168,7 +168,7 @@
         el: '#msg',
         data: {
             parent: "phaser-canvas",
-            assets_root: "{% static '' %}",
+            assets_root: "{% static '' %}".replace(/\/$/, ""),
             urls: {
                 start_game: "{% url 'start_game' %}",
                 agent_think: "{% url 'agent_think' %}",


### PR DESCRIPTION
Avoid the double slashes ('//') in addresses like http://127.0.0.1:8000/static//assets/village/tilemap/tilemap.json, as they may cause source loading failures like no map displayed.
![image](https://github.com/user-attachments/assets/f801237d-f6a3-4e1e-bef5-58ec71c64cdc)
